### PR TITLE
feat: Add peribolos without --confirm as presubmit

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -11,6 +11,38 @@ presubmits:
             - "pre-commit"
             - "run"
             - "--all-files"
+  - name: peribolos
+    decorate: true
+    run_if_changed: github-config.yaml
+    skip_report: false
+    context: community-management/prow/peribolos
+    spec:
+      containers:
+        - image: gcr.io/k8s-prow/peribolos:latest
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - |
+              set -ex
+              /peribolos --config-path github-config.yaml --github-token-path /etc/github/oauth \
+                --min-admins=2 \
+                --maximum-removal-delta=0.15 \
+                --require-self=true \
+                --fix-org \
+                --fix-org-members \
+                --fix-repos \
+                --fix-teams \
+                --fix-team-members \
+                --fix-team-repos \
+                --allow-repo-archival \
+          volumeMounts:
+            - name: github-oauth
+              mountPath: /etc/github
+      volumes:
+        - name: github-oauth
+          secret:
+            secretName: oauth-token
 
 postsubmits:
   - name: peribolos


### PR DESCRIPTION
Without `--confirm` peribolos runs a dry run. This job should be able to tell us if the peribolos spec is valid.