### PR TITLE
feat: Add project meteor repo

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -234,6 +234,10 @@ orgs:
           push the image to quay registry, pull that image and run the cuda code on
           GPU.
         has_projects: true
+      meteor:
+        description: Project meteor
+        has_projects: false
+        has_wiki: false
       mlflow-tracking-operator:
         description: MLFlow Tracking Operator for Kubernetes and OpenShift
         has_projects: true
@@ -472,6 +476,27 @@ orgs:
         privacy: closed
         repos:
           Varangian: triage
+      Meteor:
+        description: Project Meteor
+        maintainers:
+          - goern
+          - durandom
+          - tumido
+        members:
+          - MichaelClifford
+          - hemajv
+          - 4n4nd
+          - chauhankaranraj
+          - fridex
+          - harshad16
+          - HumairAK
+          - isabelizimm
+          - KPostOffice
+          - pacospace
+          - Shreyanand
+        privacy: closed
+        repos:
+          meteor: admin
       SRE:
         description: The AI CoE SRE
         maintainers:


### PR DESCRIPTION
This config should be applied only after the repo is transferred (I don't want to be moving the issues individually)

/hold

Requires: https://github.com/AICoE/common/pull/3 so I can transfer the repo


/assign @goern 

