### PR TITLE
fix: Issue templates not accepted

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -3,7 +3,7 @@ name: Organization Membership Request
 about: Request membership in AICoE Org
 title: 'REQUEST: New membership for <your-GH-handle>'
 labels: bot
-assignees: '@goern, @tumido'
+assignees: goern, tumido
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/repo-archive.md
+++ b/.github/ISSUE_TEMPLATE/repo-archive.md
@@ -3,8 +3,7 @@ name: Repository archival
 about: Retire and archive an AICoE repository
 title: RETIRE: <repo_name>
 labels: bot
-assignees: '@goern, @tumido'
-
+assignees: goern, tumido
 ---
 
 ### Repository to archive

--- a/.github/ISSUE_TEMPLATE/repo-create.md
+++ b/.github/ISSUE_TEMPLATE/repo-create.md
@@ -3,8 +3,7 @@ name: Repository creation
 about: Create a repository in AICoE Org
 title: CREATE: <repo_name>
 labels: bot
-assignees: '@goern, @tumido'
-
+assignees: goern, tumido
 ---
 
 ### New Repository


### PR DESCRIPTION
Some Issue templates are not shown. I think it may be the assignees/whitespace causing it, but who knows :shrug: 

![image](https://user-images.githubusercontent.com/7453394/123804121-3d2adc80-d8ed-11eb-97e0-35169e70c196.png)
