### PR TITLE
add oindrillac to AICoE and Meteor

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -49,6 +49,7 @@ orgs:
       - MichaelClifford
       - mroman-redhat
       - nakfour
+      - oindrillac
       - pacospace
       - rimolive
       - sahilsuneja1
@@ -485,15 +486,16 @@ orgs:
           - durandom
           - tumido
         members:
-          - MichaelClifford
-          - hemajv
           - 4n4nd
           - chauhankaranraj
           - fridex
           - harshad16
+          - hemajv
           - HumairAK
           - isabelizimm
           - KPostOffice
+          - MichaelClifford
+          - oindrillac
           - pacospace
           - Shreyanand
         privacy: closed


### PR DESCRIPTION
closes #11

Signed-off-by: Christoph Görn <goern@redhat.com>
