### PR TITLE
Add readme + fix labels job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -51,13 +51,10 @@ presubmits:
     spec:
       containers:
         - image: gcr.io/k8s-prow/label_sync:latest
-          command:
-            - /bin/sh
           args:
-            - -c
-            - |
-              set -ex
-              /label_sync --config labels.yaml --orgs=AICoE --token /etc/github/oauth
+            - --config=labels.yaml
+            - --orgs=AICoE
+            - --token=/etc/github/oauth
           volumeMounts:
             - name: github-oauth
               mountPath: /etc/github
@@ -67,10 +64,11 @@ presubmits:
             secretName: oauth-token
 
 postsubmits:
-  - name: peribolos
+  - name: aicoe-peribolos
     decorate: true
     run_if_changed: ^github-config\.yaml$
     skip_report: false
+    context: community-management/prow/peribolos
     branches:
       - ^main$
     spec:
@@ -101,22 +99,21 @@ postsubmits:
         - name: github-oauth
           secret:
             secretName: oauth-token
-  - name: labels
+  - name: aicoe-labels
     decorate: true
     run_if_changed: ^(github-config|labels)\.yaml$
     skip_report: false
+    context: community-management/prow/labels
     branches:
       - ^main$
     spec:
       containers:
         - image: gcr.io/k8s-prow/label_sync:latest
-          command:
-            - /bin/sh
           args:
-            - -c
-            - |
-              set -ex
-              /label_sync --config labels.yaml --orgs=AICoE --token /etc/github/oauth --confirm
+            - --config=labels.yaml
+            - --orgs=AICoE
+            - --token=/etc/github/oauth
+            - --confirm
           volumeMounts:
             - name: github-oauth
               mountPath: /etc/github

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# AICoE organization
+
+[![](https://prow.operate-first.cloud/badge.svg?jobs=aicoe-*)](https://prow.operate-first.cloud/?repo=AICoE%2Fcommon&type=postsubmit)
+
+## Labels
+
+Please check out [AICoE GitHub Organization Labels](labels.md) for available labels in this organization. Labels are defined in [labels.yaml](labels.yaml). You can apply those labels via Prow chat-ops commands like `/kind`, `/area` etc. For more detail on Prow commands please consult [command help](https://prow.operate-first.cloud/command-help).
+
+## Git Hub organization
+
+Git Hub organization is configured according to the [github-config.yaml](github-config.yaml) file.
+
+---
+
+Uses Prow ([Labels][1] and [Peribolos][2] plugins) to declaratively manage Git Hub organization and repositories.
+
+[1]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos
+[2]: https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos


### PR DESCRIPTION
- Adds a readme linking to Prow and other docs 
- renames the postsublit jobs to be unique for this org, so we can generate a badge for it.
- fix labels job spec to use the default entrypoint