### PR TITLE
Update colors for meteor area labels

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -295,7 +295,7 @@ default:
 repos:
   AICoE/meteor:
     labels:
-      - color: 0052cc
+      - color: 5cdfed
         description: Issues or PRs related to Team Comet
         name: area/comet
         previously:
@@ -304,7 +304,7 @@ repos:
           - name: dizzy comet
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: edcb5c
         description: Issues or PRs related to Team Shooting Star
         name: area/shooting-star
         previously:


### PR DESCRIPTION
I changed the colors for the labels `area/comet` and `area/shooting-star` so that each of the three area  labels would be more visually distinct. 

comet:
![image](https://user-images.githubusercontent.com/4494906/124030693-6ec2a700-d9c4-11eb-88a5-721e8a6e7136.png)

shooting-star:
![image](https://user-images.githubusercontent.com/4494906/124030807-8a2db200-d9c4-11eb-91f0-cde38ab83fe0.png)
