### PR TITLE
Add Pep to summit demo team and set donkeycar repo settings

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -163,7 +163,8 @@ orgs:
           get started working with the back blaze data
         has_projects: true
       donkeycar:
-        default_branch: dev
+        default_branch: aicoe
+        has_issues: true
         has_projects: false
         has_wiki: false
       edge-tekton-model:
@@ -594,6 +595,7 @@ orgs:
           - cooktheryan
           - fzdarsky
           - lukehinds
+          - codificat
         members:
           - riekrh
         privacy: closed


### PR DESCRIPTION
I believe it's better to have a new branch for our changes to the `donkeycar` repo. One change that is currently on the table is to add configuration for the pipelines; even if that should not create conflicts with upstream, a different branch should help make sure things are clean and help control updates.

Also adding myself as a maintainer to contribute on that effort.
