### PR TITLE
Add missing triage labels

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -60,7 +60,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /app/label_sync/app.binary \
+              /ko-app/label_sync \
               --config=labels.yaml \
               --orgs=AICoE \
               --endpoint=http://ghproxy \
@@ -129,7 +129,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /app/label_sync/app.binary \
+              /ko-app/label_sync \
               --config=labels.yaml \
               --orgs=AICoE \
               --endpoint=http://ghproxy \

--- a/labels.yaml
+++ b/labels.yaml
@@ -249,6 +249,12 @@ default:
       prowPlugin: label
       addedBy: humans
 
+    - color: 8fc951
+      description: Indicates an issue or PR is ready to be actively worked on.
+      name: triage/accepted
+      target: both
+      prowPlugin: label
+      addedBy: org members
     - color: d455d0
       description: Indicates an issue is a duplicate of other open issue.
       name: triage/duplicate


### PR DESCRIPTION
The AICoE repos are missing a couple of labels that are used for issue triage: `needs-triage` and `triage/accepted`.

Example issues showing that gap in action include https://github.com/AICoE/manage-dependencies-tutorial/issues/25#issuecomment-966223937, https://github.com/AICoE/sefkhet-abwy/issues/184#issuecomment-966444744, https://github.com/AICoE/aicoe-ci/issues/153#issuecomment-979304089

This PR adds these two labels.