### PR TITLE
Update the path to the peribolos binary

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -25,7 +25,7 @@ presubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml \
+              /ko-app/peribolos --config-path github-config.yaml \
                 --github-endpoint=http://ghproxy \
                 --github-endpoint=https://api.github.com \
                 --github-token-path /etc/github/oauth \
@@ -91,7 +91,7 @@ postsubmits:
             - -c
             - |
               set -ex
-              /peribolos --config-path github-config.yaml \
+              /ko-app/peribolos --config-path github-config.yaml \
                 --github-endpoint=http://ghproxy \
                 --github-endpoint=https://api.github.com \
                 --github-token-path /etc/github/oauth \


### PR DESCRIPTION
Update the path to the `peribolos` binary inside the prow image.

This is the same change as https://github.com/open-services-group/community/pull/83

Related to https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md?plain=1#L195

