### PR TITLE
Remove the meteor-operator repo from gh org configuration

### DIFF
--- a/github-config.yaml
+++ b/github-config.yaml
@@ -612,7 +612,6 @@ orgs:
         privacy: closed
         repos:
           meteor: write
-          meteor-operator: write
           data-driven-development: write
       Seraph:
         descriptio: Seraph community project
@@ -700,7 +699,6 @@ orgs:
           matmul-pipeline-cpu: admin
           matmul-pipeline-gpu: admin
           meteor: admin
-          meteor-operator: admin
           olm-testing-example: admin
           openshift_kubeflow_workshop: admin
           overlays-for-ai-pipeline-tutorial: admin


### PR DESCRIPTION
The peribolos post-submit job after #59 failed due to:

``` json
{
  "component": "peribolos",
  "file": "k8s.io/test-infra/prow/cmd/peribolos/main.go:194",
  "func": "main.main",
  "level": "fatal",
  "msg": "Configuration failed: failed to configure AICoE team Meteor repos: failed to update team 4924239(Meteor) permissions on repo meteor-operator to write: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams/#add-or-update-team-repository-permissions\"}",
  "severity": "fatal",
  "time": "2022-12-12T15:07:44Z"
}
```

The `meteor-operator` repo was transferred to the [thoth-station github org](https://github.com/thoth-station/meteor-operator), hence why it is not found.

This PR removes references to the `meteor-operator` repo from the AICoE peribolos configuration.